### PR TITLE
fix: 处理初始化时多次请求

### DIFF
--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -50,8 +50,11 @@ export function createWorkerFunc() {
     if (code === "pause") {
       clearInterval(timer);
       timer = null;
-    } else {
+    } else if (code === "resume") {
+      // 标签页激活时检测一次
       immediate && runReq();
+      timer = setInterval(runReq, pollingInterval);
+    } else {
       timer = setInterval(runReq, pollingInterval);
     }
   };


### PR DESCRIPTION
在使用的时候发现一个现象：
当开启`immediate`配置时，页面第一次进来时，会发送两次请求。
第一次请求是：
https://github.com/JoeshuTT/version-polling/blob/4fbdc9bb8036c695f47c1aa9f0377307c29adb41/src/index.ts#L49-L52

第二次请求是：
https://github.com/JoeshuTT/version-polling/blob/4fbdc9bb8036c695f47c1aa9f0377307c29adb41/src/utils/index.ts#L50-L56

然而第二次请求是不应该触发的。
所以将判断逻辑改为：
```javascript
if (code === "pause") { 
   clearInterval(timer); 
 timer = null; 
}  else if (code === "resume") {
  // 标签页激活时检测一次
  immediate && runReq();
  timer = setInterval(runReq, pollingInterval);
} else {
  timer = setInterval(runReq, pollingInterval);
}
```